### PR TITLE
refactor: Update prefix logic in DA

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -156,7 +156,8 @@
             },
             {
               "key": "prefix",
-              "required": true
+              "required": true,
+              "decsription": "Prefix to add to all resources created by this solution. To not use any prefix value, you can enter the string `__NULL__`."
             },
             {
               "key": "resource_group_name",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -157,7 +157,7 @@
             {
               "key": "prefix",
               "required": true,
-              "decsription": "Prefix to add to all resources created by this solution. To not use any prefix value, you can enter the string `__NULL__`."
+              "description": "Prefix to add to all resources created by this solution. To not use any prefix value, you can enter the string `__NULL__`."
             },
             {
               "key": "resource_group_name",

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -1,7 +1,9 @@
 #######################################################################################################################
 # Local Variables
 #######################################################################################################################
-
+locals {
+  prefix = var.prefix != null ? (var.prefix != "" ? var.prefix : null) : null
+}
 locals {
 
   # tflint-ignore: terraform_unused_declarations
@@ -13,10 +15,10 @@ locals {
 
   default_cos_region = var.cos_region != null ? var.cos_region : var.region
 
-  cos_key_ring_name           = var.prefix != null ? "${var.prefix}-${var.cos_key_ring_name}" : var.cos_key_ring_name
-  cos_key_name                = var.prefix != null ? "${var.prefix}-${var.cos_key_name}" : var.cos_key_name
-  log_archive_cos_bucket_name = var.prefix != null ? "${var.prefix}-${var.log_archive_cos_bucket_name}" : var.log_archive_cos_bucket_name
-  at_cos_target_bucket_name   = var.prefix != null ? "${var.prefix}-${var.at_cos_target_bucket_name}" : var.at_cos_target_bucket_name
+  cos_key_ring_name           = try("${local.prefix}-${var.cos_key_ring_name}", var.cos_key_ring_name)
+  cos_key_name                = try("${local.prefix}-${var.cos_key_name}", var.cos_key_name)
+  log_archive_cos_bucket_name = try("${local.prefix}-${var.log_archive_cos_bucket_name}", var.log_archive_cos_bucket_name)
+  at_cos_target_bucket_name   = try("${local.prefix}-${var.at_cos_target_bucket_name}", var.at_cos_target_bucket_name)
 
   cos_instance_crn  = var.existing_cos_instance_crn != null ? var.existing_cos_instance_crn : length(module.cos_instance) != 0 ? module.cos_instance[0].cos_instance_crn : null
   cos_instance_guid = var.existing_cos_instance_crn == null ? length(module.cos_instance) != 0 ? module.cos_instance[0].cos_instance_guid : null : element(split(":", var.existing_cos_instance_crn), length(split(":", var.existing_cos_instance_crn)) - 3)
@@ -47,10 +49,10 @@ locals {
   cos_target_bucket_name     = var.existing_at_cos_target_bucket_name != null ? var.existing_at_cos_target_bucket_name : var.enable_at_event_routing_to_cos_bucket ? module.cos_bucket[0].buckets[local.at_cos_target_bucket_name].bucket_name : null
   cos_resource_group_id      = var.cos_resource_group_name != null ? module.cos_resource_group[0].resource_group_id : module.resource_group.resource_group_id
   cos_target_bucket_endpoint = var.existing_at_cos_target_bucket_endpoint != null ? var.existing_at_cos_target_bucket_endpoint : var.enable_at_event_routing_to_cos_bucket ? module.cos_bucket[0].buckets[local.at_cos_target_bucket_name].s3_endpoint_private : null
-  cos_target_name            = var.prefix != null ? "${var.prefix}-cos-target" : "cos-target"
-  cloud_logs_target_name     = var.prefix != null ? "${var.prefix}-cloud-logs-target" : "cloud-logs-target"
-  at_cos_route_name          = var.prefix != null ? "${var.prefix}-at-cos-route" : "at-cos-route"
-  at_cloud_logs_route_name   = var.prefix != null ? "${var.prefix}-at-cloud-logs-route" : "at-cloud-logs-route"
+  cos_target_name            = try("${local.prefix}-cos-target", "cos-target")
+  cloud_logs_target_name     = try("${local.prefix}-cloud-logs-target", "cloud-logs-target")
+  at_cos_route_name          = try("${local.prefix}-at-cos-route", "at-cos-route")
+  at_cloud_logs_route_name   = try("${local.prefix}-at-cloud-logs-route", "at-cloud-logs-route")
 
   archive_bucket_config = var.manage_log_archive_cos_bucket ? {
     class = var.log_archive_cos_bucket_class
@@ -110,13 +112,13 @@ locals {
 
 
   # Cloud Logs data bucket
-  cloud_log_data_bucket = var.prefix != null ? "${var.prefix}-${var.cloud_log_data_bucket_name}" : var.cloud_log_data_bucket_name
+  cloud_log_data_bucket = try("${local.prefix}-${var.cloud_log_data_bucket_name}", var.cloud_log_data_bucket_name)
 
   parsed_log_data_bucket_name         = var.existing_cloud_logs_data_bucket_crn != null ? split(":", var.existing_cloud_logs_data_bucket_crn) : []
   existing_cloud_log_data_bucket_name = length(local.parsed_log_data_bucket_name) > 0 ? local.parsed_log_data_bucket_name[1] : null
 
   # Cloud Logs metrics bucket
-  cloud_log_metrics_bucket = var.prefix != null ? "${var.prefix}-${var.cloud_log_metrics_bucket_name}" : var.cloud_log_metrics_bucket_name
+  cloud_log_metrics_bucket = try("${local.prefix}-${var.cloud_log_metrics_bucket_name}", var.cloud_log_metrics_bucket_name)
 
   parsed_log_metrics_bucket_name         = var.existing_cloud_logs_metrics_bucket_crn != null ? split(":", var.existing_cloud_logs_metrics_bucket_crn) : []
   existing_cloud_log_metrics_bucket_name = length(local.parsed_log_metrics_bucket_name) > 0 ? local.parsed_log_metrics_bucket_name[1] : null
@@ -136,7 +138,7 @@ locals {
 module "resource_group" {
   source                       = "terraform-ibm-modules/resource-group/ibm"
   version                      = "1.1.6"
-  resource_group_name          = var.use_existing_resource_group == false ? (var.prefix != null ? "${var.prefix}-${var.resource_group_name}" : var.resource_group_name) : null
+  resource_group_name          = var.use_existing_resource_group == false ? (try("${local.prefix}-${var.resource_group_name}", var.resource_group_name)) : null
   existing_resource_group_name = var.use_existing_resource_group == true ? var.resource_group_name : null
 }
 
@@ -147,7 +149,7 @@ module "cos_resource_group" {
   }
   source              = "terraform-ibm-modules/resource-group/ibm"
   version             = "1.1.6"
-  resource_group_name = var.prefix != null ? "${var.prefix}-${var.cos_resource_group_name}" : var.cos_resource_group_name
+  resource_group_name = try("${local.prefix}-${var.cos_resource_group_name}", var.cos_resource_group_name)
 }
 
 #######################################################################################################################
@@ -157,8 +159,8 @@ module "cos_resource_group" {
 locals {
   parsed_existing_cloud_monitoring_crn = var.existing_cloud_monitoring_crn != null ? split(":", var.existing_cloud_monitoring_crn) : []
   existing_cloud_monitoring_guid       = length(local.parsed_existing_cloud_monitoring_crn) > 0 ? local.parsed_existing_cloud_monitoring_crn[7] : null
-  cloud_monitoring_instance_name       = var.prefix != null ? "${var.prefix}-${var.cloud_monitoring_instance_name}" : var.cloud_monitoring_instance_name
-  cloud_logs_instance_name             = var.prefix != null ? "${var.prefix}-cloud-logs" : var.cloud_logs_instance_name
+  cloud_monitoring_instance_name       = try("${local.prefix}-${var.cloud_monitoring_instance_name}", var.cloud_monitoring_instance_name)
+  cloud_logs_instance_name             = try("${local.prefix}-cloud-logs", var.cloud_logs_instance_name)
   cloud_logs_data_bucket_crn           = var.existing_cloud_logs_data_bucket_crn != null ? var.existing_cloud_logs_data_bucket_crn : module.cos_bucket[0].buckets[local.cloud_log_data_bucket].bucket_crn
   cloud_log_metrics_bucket_crn         = var.existing_cloud_logs_metrics_bucket_crn != null ? var.existing_cloud_logs_metrics_bucket_crn : module.cos_bucket[0].buckets[local.cloud_log_metrics_bucket].bucket_crn
   cloud_logs_buckets                   = [local.cloud_logs_data_bucket_crn, local.cloud_log_metrics_bucket_crn]
@@ -254,7 +256,7 @@ module "observability_instance" {
   cloud_logs_existing_en_instances = [for index, _ in local.cloud_logs_existing_en_instances : {
     en_instance_id      = module.en_crn_parser[index]["service_instance"]
     en_region           = module.en_crn_parser[index]["region"]
-    en_integration_name = var.prefix != null ? "${var.prefix}-${local.cloud_logs_existing_en_instances[index]["integration_name"]}" : local.cloud_logs_existing_en_instances[index]["integration_name"]
+    en_integration_name = try("${local.prefix}-${local.cloud_logs_existing_en_instances[index]["integration_name"]}", local.cloud_logs_existing_en_instances[index]["integration_name"])
     skip_en_auth_policy = local.cloud_logs_existing_en_instances[index]["skip_en_auth_policy"]
   }]
   skip_logs_routing_auth_policy = var.skip_logs_routing_auth_policy
@@ -412,7 +414,7 @@ module "cos_instance" {
   version                  = "8.14.1"
   resource_group_id        = local.cos_resource_group_id
   create_cos_instance      = true
-  cos_instance_name        = var.prefix != null ? "${var.prefix}-${var.cos_instance_name}" : var.cos_instance_name
+  cos_instance_name        = try("${local.prefix}-${var.cos_instance_name}", var.cos_instance_name)
   cos_tags                 = var.cos_instance_tags
   existing_cos_instance_id = var.existing_cos_instance_crn
   access_tags              = var.cos_instance_access_tags

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -48,8 +48,8 @@ variable "region" {
 
 variable "prefix" {
   type        = string
-  description = "The prefix to add to all resources that this solution creates."
-  default     = ""
+  description = "The prefix to add to all resources that this solution creates. To not use any prefix value, you can set this value to `null` or an empty string."
+  default     = "dev"
 }
 
 ##############################################################################

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-ibm-modules/terraform-ibm-observability-da
+module github.com/terraform-ibm-modules/experimental-terraform-ibm-observability-da
 
 go 1.22.0
 


### PR DESCRIPTION
### Description

Updated the code logic of prefix variable such that it allows prefix to be "" (empty string) for advanced users. Also, added default value(dev) for prefix and marked as required in catalog manifest.

[#11959](https://github.ibm.com/GoldenEye/issues/issues/11959)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Adds the default value for prefix variable and mark as required in catalog manifest. Also allows prefix to be "" (empty string ).

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
