### PR TITLE
fix(deps): update account infra base addon to rg-only v2.0.6

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -741,7 +741,7 @@
               "on_by_default": true,
               "input_mapping": [
                 {
-                  "dependency_output": "observability_resource_group_name",
+                  "dependency_output": "global_resource_group_name",
                   "version_input": "resource_group_name"
                 },
                 {

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -732,9 +732,9 @@
             {
               "name": "deploy-arch-ibm-account-infra-base",
               "id": "63641cec-6093-4b4f-b7b0-98d2f4185cd6-global",
-              "version": "^v1.19.0",
+              "version": "^v2.0.5",
               "flavors": [
-                "standard"
+                "resource-group-only"
               ],
               "catalog_id": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3",
               "optional": true,
@@ -749,9 +749,18 @@
                   "version_input": "use_existing_resource_group"
                 },
                 {
+                  "dependency_input": "provider_visibility",
+                  "version_input": "provider_visibility",
+                  "reference_version": true
+                },
+                {
                   "dependency_input": "prefix",
                   "version_input": "prefix",
                   "reference_version": true
+                },
+                {
+                  "dependency_input": "global_resource_group_name",
+                  "value": "observability-rg"
                 }
               ],
               "ignore_auto_referencing": [

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -732,7 +732,7 @@
             {
               "name": "deploy-arch-ibm-account-infra-base",
               "id": "63641cec-6093-4b4f-b7b0-98d2f4185cd6-global",
-              "version": "^v2.0.5",
+              "version": "^v2.0.6",
               "flavors": [
                 "resource-group-only"
               ],


### PR DESCRIPTION
### Description
Update the account infrastructure base add on to v2.0.6 and migrate to the resource group only flavor

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
